### PR TITLE
feat: use block_id to get and update right counter

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -7,7 +7,7 @@ export const GET_COUNTER = 'GET_COUNTER';
  * resetCounter action
  * @module actions/resetCounter
  */
-export function resetCounter({ path, value }) {
+export function resetCounter({ path, value, block_id = null }) {
   // const pagePath = expandToBackendURL(path);
 
   return {
@@ -15,7 +15,7 @@ export function resetCounter({ path, value }) {
     request: {
       op: 'patch',
       path: `${path}/@counter`,
-      data: { counter_value: value },
+      data: { counter_value: value, block_id },
     },
   };
 }
@@ -25,14 +25,18 @@ export function resetCounter({ path, value }) {
  * @module actions/counter
  * Parameters: block_id (optional) — The identifier of the form block. The first available is being selected if not passed.
  */
-export function getCounterValue({ path }) {
+export function getCounterValue({ path, block_id = null }) {
   // const pagePath = expandToBackendURL(path);
+  let options = {
+    op: 'get',
+    path: `${path}/@counter`,
+  };
+  if (block_id) {
+    options.params = { block_id };
+  }
 
   return {
     type: GET_COUNTER,
-    request: {
-      op: 'get',
-      path: `${path}/@counter`,
-    },
+    request: options,
   };
 }

--- a/src/components/Widgets/CounterWidget/CounterWidget.jsx
+++ b/src/components/Widgets/CounterWidget/CounterWidget.jsx
@@ -41,9 +41,10 @@ const CounterWidget = (props) => {
   const location = useLocation();
   const dispatch = useDispatch();
 
+  const { block } = props;
   const resetCounterState = useSelector((state) => state.resetCounterState);
   const counterState = useSelector((state) => state.counterValueState);
-  const counterValue = counterState?.result?.counter_value ?? 0;
+  const counterValue = counterState?.result?.[block] ?? 0;
 
   const [showNotify, setShowNotify] = useState(false);
   const [notifyError, setNotifyError] = useState(false);
@@ -57,6 +58,7 @@ const CounterWidget = (props) => {
       dispatch(
         getCounterValue({
           path: getBaseUrl(location?.pathname || ''),
+          block_id: block,
         }),
       );
     }
@@ -79,6 +81,7 @@ const CounterWidget = (props) => {
     dispatch(
       getCounterValue({
         path: getBaseUrl(location?.pathname || ''),
+        block_id: block,
       }),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,6 +118,7 @@ const CounterWidget = (props) => {
               resetCounter({
                 path: getBaseUrl(location?.pathname || ''),
                 value: counterInput,
+                block_id: block,
               }),
             );
           }}
@@ -138,30 +142,6 @@ const CounterWidget = (props) => {
             <small>{intl.formatMessage(messages.counter_success)}</small>
           </div>
         )}
-
-        {/* {counterValue > 0 && (
-          <>
-            {/* RESET BUTTON
-            <Button
-              onClick={() =>
-                dispatch(
-                  resetCounter({
-                    path: getBaseUrl(location?.pathname || ''),
-                  }),
-                )
-              }
-              size="tiny"
-              compact
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-              }}
-            >
-              <Icon name={deleteSVG} size="1.5rem" />{' '}
-              {intl.formatMessage(messages.reset_label)}
-            </Button>
-          </>
-        )} */}
       </div>
     </Grid.Row>
   );


### PR DESCRIPTION
This is related to https://github.com/collective/volto-form-block/pull/144

With this change, we can read the right counter data from the backend, also if there are more form blocks in the same context.